### PR TITLE
hide group layers when no sublayer matches filter

### DIFF
--- a/src/Components/Layers/utils/layers.ts
+++ b/src/Components/Layers/utils/layers.ts
@@ -175,30 +175,16 @@ export const filterLayers = (value: string, layerList: __esri.LayerList): void =
           });
         }
       });
-      if (!value.length) {
-        item.open = false;
+      item.open = value.length > 0 && open;
+      if (!value.length || open) {
         document
           .getElementById(`${(layerList as any).id}_${(item as any).uid}__title`)
           ?.parentElement?.parentElement?.parentElement?.removeAttribute('hidden');
-        document
-          .querySelector(`#layerListDiv_${(item as any).uid}__title`)
-          ?.parentElement?.parentElement?.parentElement?.removeAttribute('hidden');
-      } else if (!open) {
-        item.open = false;
+      }
+      if (!open) {
         document
           .getElementById(`${(layerList as any).id}_${(item as any).uid}__title`)
           ?.parentElement?.parentElement?.parentElement?.setAttribute('hidden', '');
-        document
-          .querySelector(`#layerListDiv_${(item as any).uid}__title`)
-          ?.parentElement?.parentElement?.parentElement?.setAttribute('hidden', '');
-      } else {
-        item.open = true;
-        document
-          .getElementById(`${(layerList as any).id}_${(item as any).uid}__title`)
-          ?.parentElement?.parentElement?.parentElement?.removeAttribute('hidden');
-        document
-          .querySelector(`#layerListDiv_${(item as any).uid}__title`)
-          ?.parentElement?.parentElement?.parentElement?.removeAttribute('hidden');
       }
     }
   });

--- a/src/Components/Layers/utils/layers.ts
+++ b/src/Components/Layers/utils/layers.ts
@@ -178,15 +178,24 @@ export const filterLayers = (value: string, layerList: __esri.LayerList): void =
       if (!value.length) {
         item.open = false;
         document
+          .getElementById(`${(layerList as any).id}_${(item as any).uid}__title`)
+          ?.parentElement?.parentElement?.parentElement?.removeAttribute('hidden');
+        document
           .querySelector(`#layerListDiv_${(item as any).uid}__title`)
           ?.parentElement?.parentElement?.parentElement?.removeAttribute('hidden');
       } else if (!open) {
         item.open = false;
         document
+          .getElementById(`${(layerList as any).id}_${(item as any).uid}__title`)
+          ?.parentElement?.parentElement?.parentElement?.setAttribute('hidden', '');
+        document
           .querySelector(`#layerListDiv_${(item as any).uid}__title`)
           ?.parentElement?.parentElement?.parentElement?.setAttribute('hidden', '');
       } else {
         item.open = true;
+        document
+          .getElementById(`${(layerList as any).id}_${(item as any).uid}__title`)
+          ?.parentElement?.parentElement?.parentElement?.removeAttribute('hidden');
         document
           .querySelector(`#layerListDiv_${(item as any).uid}__title`)
           ?.parentElement?.parentElement?.parentElement?.removeAttribute('hidden');


### PR DESCRIPTION
Essentially all I did was replace `.querySelector()` with `.getElementById()` in the `filterLayers()` function. I changed the selector to `getElementById()` because `querySelector()` does not allow ids that start with a digit. 

I also replaced the `#layerListDiv` with `${(layerList as any).id}` since I couldn't figure out what `#layerListDiv` referred to. 

I left the `.querySelector('#layerListDiv_${(item as any).uid}__title')` lines in case they are doing something I am not aware of, but you may want to remove them if they aren't needed. I did do some manual testing with these lines removed and didn't get any console errors or variation in behavior.

## ONE CONSIDERATION BEFORE MERGING:
If there are no layers that match the filter term, nothing is displayed. You may want to consider adding some info text in this case like "No layers match the current filter" to prompt the user to refine their filter. **I would be happy to write this functionality but wanted to keep this PR simple for now**. This is what it would look like if you merged this PR as is: 
<img width="267" alt="Screen Shot 2021-10-26 at 3 09 18 PM" src="https://user-images.githubusercontent.com/55759619/138945189-dd79177d-b1eb-445c-be3e-cf47849ecb11.png">

Here are images of the proposed change:
![imaps_layer_list_proposal](https://user-images.githubusercontent.com/55759619/138943565-1df90622-1453-4d7e-bf06-8609603bdc6a.png)
